### PR TITLE
Add randomization buckets; compact spawn assets UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,28 @@ This file guides coding agents working on MediaSpawner. It complements README.md
 - No base-asset fallback; do not store behavioral properties on `MediaAsset`.
 - Persist per-asset overrides as diffs only.
 
+## Randomization buckets (spawn-level)
+
+- `Spawn.randomizationBuckets?: RandomizationBucket[]`
+  - Members reference `spawnAssetId` (not library asset id).
+  - Selection: `"one" | "n"` (v1); `n` required when `selection === "n"`.
+  - No weights/repeat flags in v1 UI (fields may exist but are unused).
+- Invariants enforced by `validateRandomizationBuckets`:
+  - Each spawn asset may belong to at most one bucket.
+  - Members must exist in `spawn.assets` and be unique per bucket.
+  - When `selection === "n"`, require `1 ≤ n ≤ enabledMemberCount`.
+- `SpawnService.updateSpawn`:
+  - Reconciles buckets with assets (removes dangling members) and validates.
+  - Emits `mediaspawner:spawn-updated` after successful save.
+- UI:
+  - Spawn editor includes a "Randomization Buckets" section.
+  - "Edit Members" modal shows [checkbox] Name + type chip + order chip; tooltip shows full path.
+  - Assets already in a bucket are shown with a bucket chip in the right panel (Assets in Current Spawn).
+
 ## Services and events
 
 - Services:
-  - `SpawnService`: CRUD for spawn data; accepts `defaultProperties`.
+  - `SpawnService`: CRUD for spawn data; accepts `defaultProperties` and `randomizationBuckets`.
   - `AssetService`: global asset library; assets are descriptive only (no behavioral `properties`).
   - `CacheService`, `ConfigurationService`, `ImportExportService`, `SettingsService`, `SpawnProfileService` exported via `src/services/index.ts`.
 - Global events:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,23 @@ Sets of media assets that spawn together. Each spawn has its own trigger conditi
 
 Individual media files (images, videos, audio) that can be assigned to spawns with specific configuration overrides.
 
+### Randomization Buckets (per-spawn)
+
+Configure subsets of a spawn's assets to be chosen at runtime by the consuming application.
+
+- Buckets reference spawn assets (not library assets) and live on the spawn.
+- Selection modes:
+  - Pick one: exactly one member will be chosen.
+  - Pick N: choose N unique members; N must be ≤ enabled members.
+- Non-bucket assets always spawn as usual.
+- UI: create buckets, edit members, and see bucket chips next to assets in the current spawn panel.
+
 ## Features
 
 - **Spawn Management**: Create, configure, and organize spawns within profiles
 - **Asset Library**: Central repository for all your media assets
 - **Spawn-Specific Settings**: Configure how assets behave within each spawn
+- **Randomization Buckets**: Define groups that select one or N assets at runtime
 - **Profile Switching**: Work with different configurations for different scenarios
 - **Export Ready**: Generate configurations for external applications
 
@@ -43,7 +55,8 @@ Individual media files (images, videos, audio) that can be assigned to spawns wi
 2. **Add Assets** - Import your media files into the asset library
 3. **Create Spawns** - Group related assets together
 4. **Configure Settings** - Set trigger conditions, duration, and asset-specific properties
-5. **Export** - Generate configuration files for your target application
+5. **Randomize** - Optionally create randomization buckets inside a spawn
+6. **Export** - Generate configuration files for your target application
 
 ## Architecture
 

--- a/schema.json
+++ b/schema.json
@@ -89,6 +89,12 @@
                         "$ref": "#/$defs/SpawnAsset"
                     }
                 },
+                "randomizationBuckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/RandomizationBucket"
+                    }
+                },
                 "defaultProperties": {
                     "$ref": "#/$defs/AssetSettings"
                 }
@@ -105,6 +111,12 @@
             "properties": {
                 "assetId": {
                     "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "order": {
                     "type": "integer",
@@ -126,6 +138,64 @@
             },
             "required": [
                 "assetId"
+            ]
+        },
+        "RandomizationBucket": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "selection": {
+                    "type": "string",
+                    "enum": [
+                        "one",
+                        "n"
+                    ]
+                },
+                "n": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "weighted": {
+                    "type": "boolean"
+                },
+                "noImmediateRepeat": {
+                    "type": "boolean"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/RandomizationBucketMember"
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "selection",
+                "members"
+            ]
+        },
+        "RandomizationBucketMember": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "spawnAssetId": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "required": [
+                "spawnAssetId"
             ]
         },
         "Asset": {

--- a/src/components/asset-management/AssetManagementPanel.tsx
+++ b/src/components/asset-management/AssetManagementPanel.tsx
@@ -15,8 +15,18 @@ import { ConfirmDialog } from "../common/ConfirmDialog";
 import { HUICombobox } from "../common";
 import * as Popover from "@radix-ui/react-popover";
 import * as Tooltip from "@radix-ui/react-tooltip";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { toast } from "sonner";
 import { Disclosure } from "@headlessui/react";
+import {
+  GripVertical,
+  Settings,
+  MoreVertical,
+  Trash2,
+  ChevronUp,
+  ChevronDown,
+  Shuffle,
+} from "lucide-react";
 
 /**
  * AssetManagementPanel renders the right-panel structure for Epic 4 (MS-32):
@@ -316,7 +326,7 @@ function SpawnAssetsSection() {
               <li
                 role="listitem"
                 key={spawnAsset.id}
-                className={`border border-gray-200 rounded-md bg-white p-2 ${
+                className={`border border-gray-200 rounded-md bg-white p-2 focus-within:ring-2 focus-within:ring-[rgb(var(--color-ring))] ${
                   draggingId === spawnAsset.id ? "opacity-70" : ""
                 }`}
                 draggable
@@ -355,37 +365,124 @@ function SpawnAssetsSection() {
                     title="Drag to reorder"
                     aria-hidden
                   >
-                    ⋮⋮
+                    <GripVertical size={16} />
                   </div>
                   <div className="w-16 h-16 flex-shrink-0 overflow-hidden rounded">
-                    <MediaPreview
-                      asset={baseAsset}
-                      className="h-full"
-                      fit="contain"
-                    />
+                    <Popover.Root>
+                      <Popover.Trigger asChild>
+                        <div className="w-16 h-16 overflow-hidden rounded">
+                          <MediaPreview
+                            asset={baseAsset}
+                            className="h-full"
+                            fit="contain"
+                          />
+                        </div>
+                      </Popover.Trigger>
+                      <Popover.Portal>
+                        <Popover.Content
+                          sideOffset={6}
+                          className="z-10 w-72 rounded-md border border-gray-200 bg-white shadow-md p-2"
+                        >
+                          <div className="w-full h-40 overflow-hidden rounded mb-2">
+                            <MediaPreview
+                              asset={baseAsset}
+                              className="h-full"
+                              fit="contain"
+                            />
+                          </div>
+                          <div className="text-xs text-gray-700 space-y-1">
+                            <div>
+                              <span className="text-gray-500">Name:</span>{" "}
+                              {baseAsset.name}
+                            </div>
+                            <div>
+                              <span className="text-gray-500">Type:</span>{" "}
+                              {baseAsset.type}
+                            </div>
+                            <div className="truncate" title={baseAsset.path}>
+                              <span className="text-gray-500">Path:</span>{" "}
+                              {baseAsset.path}
+                            </div>
+                          </div>
+                          <Popover.Arrow className="fill-white" />
+                        </Popover.Content>
+                      </Popover.Portal>
+                    </Popover.Root>
                   </div>
                   <div className="flex-1 min-w-0">
                     <div
                       className="text-sm font-medium text-gray-900 truncate"
                       title={baseAsset.name}
                     >
-                      {baseAsset.name}
+                      <Tooltip.Root>
+                        <Tooltip.Trigger asChild>
+                          <span className="truncate inline-block max-w-full align-middle">
+                            {baseAsset.name}
+                          </span>
+                        </Tooltip.Trigger>
+                        <Tooltip.Portal>
+                          <Tooltip.Content
+                            sideOffset={6}
+                            className="z-10 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-800 shadow-md"
+                          >
+                            {baseAsset.name}
+                            <Tooltip.Arrow className="fill-white" />
+                          </Tooltip.Content>
+                        </Tooltip.Portal>
+                      </Tooltip.Root>
                     </div>
-                    <div className="text-xs text-gray-600 flex items-center gap-2">
-                      <span className="inline-flex items-center gap-1 capitalize bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
+                    <div className="text-xs text-gray-600 flex items-center gap-1.5">
+                      <span className="inline-flex items-center gap-1 capitalize bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded">
                         <span>{getTypeIcon(baseAsset.type)}</span>
                         <span>{baseAsset.type}</span>
                       </span>
+                      {spawn?.randomizationBuckets?.length
+                        ? (() => {
+                            const bucket = (
+                              spawn.randomizationBuckets || []
+                            ).find((b) =>
+                              b.members.some(
+                                (m) => m.spawnAssetId === spawnAsset.id
+                              )
+                            );
+                            return bucket ? (
+                              <Tooltip.Root>
+                                <Tooltip.Trigger asChild>
+                                  <span
+                                    className="inline-flex items-center justify-center bg-blue-50 text-blue-700 w-6 h-6 rounded border border-blue-200"
+                                    aria-label={`Bucket: ${bucket.name}`}
+                                  >
+                                    <Shuffle size={14} />
+                                  </span>
+                                </Tooltip.Trigger>
+                                <Tooltip.Portal>
+                                  <Tooltip.Content
+                                    sideOffset={6}
+                                    className="z-10 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-800 shadow-md"
+                                  >
+                                    Bucket: {bucket.name}
+                                    <Tooltip.Arrow className="fill-white" />
+                                  </Tooltip.Content>
+                                </Tooltip.Portal>
+                              </Tooltip.Root>
+                            ) : null;
+                          })()
+                        : null}
+                      {!spawnAsset.enabled && (
+                        <span className="inline-flex items-center gap-1 bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded text-[11px]">
+                          Disabled
+                        </span>
+                      )}
                       <span className="text-gray-400">•</span>
                       <span className="text-gray-500">
                         Order: {spawnAsset.order}
                       </span>
                     </div>
                   </div>
-                  <div className="flex items-center">
+                  <div className="flex items-center gap-1.5">
                     <button
                       type="button"
-                      className={`mr-2 text-xs px-2 py-1 rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50`}
+                      className="inline-flex items-center justify-center text-xs rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--color-ring))] focus-visible:ring-offset-2 w-7 h-7"
                       onClick={() => {
                         const detail = {
                           mode: "asset-settings",
@@ -398,17 +495,16 @@ function SpawnAssetsSection() {
                           )
                         );
                       }}
+                      aria-label="Configure"
                     >
-                      Configure
+                      <Settings size={14} />
                     </button>
                     <button
                       type="button"
-                      className={`text-xs px-2 py-1 rounded border border-gray-300 bg-white text-gray-700 ${
-                        isRemoving
-                          ? "opacity-50 cursor-not-allowed"
-                          : "hover:bg-gray-50"
-                      }`}
                       aria-label="Remove from Spawn"
+                      className={`inline-flex items-center justify-center text-xs rounded border border-red-300 bg-white text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--color-ring))] focus-visible:ring-offset-2 w-7 h-7 ${
+                        isRemoving ? "opacity-50 cursor-not-allowed" : ""
+                      }`}
                       onClick={() => {
                         if (skipRemoveConfirm) {
                           void performRemove(spawnAsset.id);
@@ -418,8 +514,69 @@ function SpawnAssetsSection() {
                       }}
                       disabled={isRemoving}
                     >
-                      Remove
+                      <Trash2 size={14} />
                     </button>
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger asChild>
+                        <button
+                          type="button"
+                          className="inline-flex items-center justify-center rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--color-ring))] focus-visible:ring-offset-2"
+                          aria-label="More actions"
+                        >
+                          <MoreVertical size={16} />
+                        </button>
+                      </DropdownMenu.Trigger>
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.Content
+                          sideOffset={6}
+                          className="z-10 rounded-md border border-gray-200 bg-white shadow-md p-1 text-sm"
+                        >
+                          <DropdownMenu.Item
+                            className="px-3 py-2 rounded data-[highlighted]:bg-gray-50 outline-none cursor-pointer"
+                            onSelect={() => {
+                              const toIndex = Math.max(0, index - 1);
+                              if (toIndex !== index)
+                                void handleReorder(index, toIndex);
+                            }}
+                          >
+                            <span className="inline-flex items-center gap-2">
+                              <ChevronUp size={14} /> Move up
+                            </span>
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Item
+                            className="px-3 py-2 rounded data-[highlighted]:bg-gray-50 outline-none cursor-pointer"
+                            onSelect={() => {
+                              const toIndex = Math.min(
+                                resolvedAssets.length - 1,
+                                index + 1
+                              );
+                              if (toIndex !== index)
+                                void handleReorder(index, toIndex);
+                            }}
+                          >
+                            <span className="inline-flex items-center gap-2">
+                              <ChevronDown size={14} /> Move down
+                            </span>
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Separator className="my-1 h-px bg-gray-200" />
+                          <DropdownMenu.Item
+                            className="px-3 py-2 rounded text-red-700 data-[highlighted]:bg-red-50 outline-none cursor-pointer"
+                            onSelect={() => {
+                              if (skipRemoveConfirm) {
+                                void performRemove(spawnAsset.id);
+                              } else {
+                                setConfirmRemoveId(spawnAsset.id);
+                              }
+                            }}
+                          >
+                            <span className="inline-flex items-center gap-2">
+                              <Trash2 size={14} /> Remove
+                            </span>
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Arrow className="fill-white" />
+                        </DropdownMenu.Content>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu.Root>
                   </div>
                 </div>
                 {dragOverIndex === index && draggingId !== null && (

--- a/src/components/configuration/RandomizationBucketsSection.tsx
+++ b/src/components/configuration/RandomizationBucketsSection.tsx
@@ -1,0 +1,396 @@
+import React, { useMemo, useState } from "react";
+import type { Spawn } from "../../types/spawn";
+import type {
+  RandomizationBucket,
+  RandomizationBucketMember,
+} from "../../types/spawn";
+import { Modal } from "../common/Modal";
+import { ConfirmDialog } from "../common/ConfirmDialog";
+import { AssetService } from "../../services/assetService";
+import * as Tooltip from "@radix-ui/react-tooltip";
+
+export interface RandomizationBucketsSectionProps {
+  spawn: Spawn;
+  buckets: RandomizationBucket[];
+  onChange: (buckets: RandomizationBucket[]) => void;
+}
+
+export const RandomizationBucketsSection: React.FC<
+  RandomizationBucketsSectionProps
+> = ({ spawn, buckets, onChange }) => {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createForm, setCreateForm] = useState<{
+    name: string;
+    selection: "one" | "n";
+    n?: number;
+  }>({
+    name: "",
+    selection: "one",
+    n: 1,
+  });
+
+  const [memberEditFor, setMemberEditFor] = useState<string | null>(null);
+  const [pendingMove, setPendingMove] = useState<{
+    assetId: string;
+    fromBucketId: string;
+    toBucketId: string;
+  } | null>(null);
+
+  const bucketByAssetId = useMemo(() => {
+    const map = new Map<string, string>();
+    buckets.forEach((b) => {
+      b.members.forEach((m) => map.set(m.spawnAssetId, b.id));
+    });
+    return map;
+  }, [buckets]);
+
+  const canCreate = useMemo(() => {
+    if (!createForm.name.trim()) return false;
+    if (createForm.selection === "n") return (createForm.n || 0) >= 1;
+    return true;
+  }, [createForm]);
+
+  const addBucket = () => {
+    if (!canCreate) return;
+    const newBucket: RandomizationBucket = {
+      id: crypto.randomUUID(),
+      name: createForm.name.trim(),
+      selection: createForm.selection,
+      n:
+        createForm.selection === "n"
+          ? Math.max(1, Number(createForm.n) || 1)
+          : undefined,
+      members: [],
+    };
+    onChange([...(buckets || []), newBucket]);
+    setCreateForm({ name: "", selection: "one", n: 1 });
+    setIsCreateOpen(false);
+  };
+
+  const removeBucket = (bucketId: string) => {
+    onChange((buckets || []).filter((b) => b.id !== bucketId));
+  };
+
+  const updateBucket = (
+    bucketId: string,
+    update: Partial<RandomizationBucket>
+  ) => {
+    onChange(
+      (buckets || []).map((b) => (b.id === bucketId ? { ...b, ...update } : b))
+    );
+  };
+
+  const openMembersEditor = (bucketId: string) => setMemberEditFor(bucketId);
+  const closeMembersEditor = () => setMemberEditFor(null);
+
+  const toggleMember = (bucketId: string, spawnAssetId: string) => {
+    const existing = bucketByAssetId.get(spawnAssetId);
+    if (existing && existing !== bucketId) {
+      setPendingMove({
+        assetId: spawnAssetId,
+        fromBucketId: existing,
+        toBucketId: bucketId,
+      });
+      return;
+    }
+
+    onChange(
+      (buckets || []).map((b) => {
+        if (b.id !== bucketId) return b;
+        const isMember = b.members.some((m) => m.spawnAssetId === spawnAssetId);
+        return {
+          ...b,
+          members: isMember
+            ? b.members.filter((m) => m.spawnAssetId !== spawnAssetId)
+            : [...b.members, { spawnAssetId } as RandomizationBucketMember],
+        };
+      })
+    );
+  };
+
+  const confirmMove = () => {
+    const move = pendingMove;
+    if (!move) return;
+    const { assetId, fromBucketId, toBucketId } = move;
+    onChange(
+      (buckets || []).map((b) => {
+        if (b.id === fromBucketId) {
+          return {
+            ...b,
+            members: b.members.filter((m) => m.spawnAssetId !== assetId),
+          };
+        }
+        if (b.id === toBucketId) {
+          if (b.members.some((m) => m.spawnAssetId === assetId)) return b;
+          return { ...b, members: [...b.members, { spawnAssetId: assetId }] };
+        }
+        return b;
+      })
+    );
+    setPendingMove(null);
+  };
+
+  const cancelMove = () => setPendingMove(null);
+
+  return (
+    <section className="bg-white border border-gray-200 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-base font-semibold text-gray-800">
+          Randomization Buckets
+        </h3>
+        <button
+          type="button"
+          onClick={() => setIsCreateOpen(true)}
+          className="px-3 py-1.5 rounded-md text-white bg-blue-600 hover:bg-blue-700"
+        >
+          Add Bucket
+        </button>
+      </div>
+
+      {(buckets || []).length === 0 ? (
+        <p className="text-sm text-gray-600">
+          No buckets yet. Create one to randomize selected assets.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {buckets.map((b) => (
+            <div key={b.id} className="border border-gray-200 rounded-md p-3">
+              <div className="flex items-center justify-between">
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-gray-900 truncate">
+                    {b.name}
+                  </div>
+                  <div className="text-xs text-gray-600">
+                    {b.selection === "one" ? "Pick one" : `Pick ${b.n ?? 1}`}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                    onClick={() => openMembersEditor(b.id)}
+                  >
+                    Edit Members ({b.members.length})
+                  </button>
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                    onClick={() =>
+                      updateBucket(b.id, {
+                        selection: b.selection === "one" ? "n" : "one",
+                        n:
+                          b.selection === "one"
+                            ? Math.min(1, (b.n as number) || 1)
+                            : undefined,
+                      })
+                    }
+                  >
+                    Toggle Mode
+                  </button>
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 rounded border border-red-300 bg-white text-red-700 hover:bg-red-50"
+                    onClick={() => removeBucket(b.id)}
+                    aria-label="Delete bucket"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+              {b.selection === "n" && (
+                <div className="mt-2">
+                  <label className="text-xs text-gray-700">N to select</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={b.n ?? 1}
+                    onChange={(e) =>
+                      updateBucket(b.id, {
+                        n: Math.max(1, Number(e.target.value) || 1),
+                      })
+                    }
+                    className="ml-2 w-20 px-2 py-1 text-sm border border-gray-300 rounded"
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        isOpen={isCreateOpen}
+        onClose={() => {
+          setIsCreateOpen(false);
+          setCreateForm({ name: "", selection: "one", n: 1 });
+        }}
+        title="Create Bucket"
+        size="md"
+      >
+        <div className="space-y-3">
+          <div>
+            <label
+              htmlFor="bucket-name"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Name
+            </label>
+            <input
+              id="bucket-name"
+              type="text"
+              value={createForm.name}
+              onChange={(e) =>
+                setCreateForm((f) => ({ ...f, name: e.target.value }))
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <label htmlFor="bucket-selection" className="text-sm text-gray-700">
+              Selection
+            </label>
+            <select
+              id="bucket-selection"
+              value={createForm.selection}
+              onChange={(e) =>
+                setCreateForm((f) => ({
+                  ...f,
+                  selection: e.target.value as "one" | "n",
+                }))
+              }
+              className="px-2 py-1 text-sm border border-gray-300 rounded"
+            >
+              <option value="one">Pick one</option>
+              <option value="n">Pick N</option>
+            </select>
+            {createForm.selection === "n" && (
+              <>
+                <label htmlFor="bucket-n" className="text-sm text-gray-700">
+                  N
+                </label>
+                <input
+                  id="bucket-n"
+                  type="number"
+                  min={1}
+                  value={createForm.n ?? 1}
+                  onChange={(e) =>
+                    setCreateForm((f) => ({
+                      ...f,
+                      n: Math.max(1, Number(e.target.value) || 1),
+                    }))
+                  }
+                  className="w-20 px-2 py-1 text-sm border border-gray-300 rounded"
+                />
+              </>
+            )}
+          </div>
+          <div className="flex items-center gap-4"></div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              className="px-3 py-1.5 rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+              onClick={() => {
+                setIsCreateOpen(false);
+                setCreateForm({ name: "", selection: "one", n: 1 });
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={!canCreate}
+              className={`px-3 py-1.5 rounded-md text-white ${
+                canCreate
+                  ? "bg-blue-600 hover:bg-blue-700"
+                  : "bg-blue-300 cursor-not-allowed"
+              }`}
+              onClick={addBucket}
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={memberEditFor !== null}
+        onClose={closeMembersEditor}
+        title="Edit Bucket Members"
+        size="xl"
+      >
+        {memberEditFor && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-[60vh] overflow-auto">
+              {spawn.assets.map((sa) => {
+                const inBucket = (
+                  buckets.find((b) => b.id === memberEditFor)?.members || []
+                ).some((m) => m.spawnAssetId === sa.id);
+                const otherBucket = bucketByAssetId.get(sa.id);
+                const base = AssetService.getAssetById(sa.assetId);
+                return (
+                  <label
+                    key={sa.id}
+                    className="flex items-center gap-2 text-sm border border-gray-200 rounded p-2"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={inBucket}
+                      onChange={() => toggleMember(memberEditFor, sa.id)}
+                    />
+                    <Tooltip.Root>
+                      <Tooltip.Trigger asChild>
+                        <span className="text-gray-800 truncate">
+                          {base?.name || sa.assetId}
+                        </span>
+                      </Tooltip.Trigger>
+                      <Tooltip.Portal>
+                        <Tooltip.Content
+                          sideOffset={6}
+                          className="z-[60] rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-800 shadow-md"
+                        >
+                          {base?.path || sa.assetId}
+                          <Tooltip.Arrow className="fill-white" />
+                        </Tooltip.Content>
+                      </Tooltip.Portal>
+                    </Tooltip.Root>
+                    <span className="inline-flex items-center gap-1 capitalize bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
+                      {base?.type || "asset"}
+                    </span>
+                    <span className="inline-flex items-center gap-1 bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
+                      #{sa.order}
+                    </span>
+                    {otherBucket && otherBucket !== memberEditFor && (
+                      <span className="ml-auto text-xs text-gray-500">
+                        In another bucket
+                      </span>
+                    )}
+                  </label>
+                );
+              })}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="px-3 py-1.5 rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                onClick={closeMembersEditor}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        isOpen={pendingMove !== null}
+        title="Move asset to this bucket?"
+        message="This asset already belongs to a different bucket. Moving it will remove it from the other bucket."
+        confirmText="Move"
+        cancelText="Cancel"
+        variant="warning"
+        onConfirm={confirmMove}
+        onCancel={cancelMove}
+      />
+    </section>
+  );
+};

--- a/src/components/configuration/__tests__/SpawnEditorWorkspace.Buckets.test.tsx
+++ b/src/components/configuration/__tests__/SpawnEditorWorkspace.Buckets.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  within,
+} from "@testing-library/react";
+import SpawnEditorWorkspace from "../SpawnEditorWorkspace";
+import { usePanelState } from "../../../hooks/useLayout";
+import { SpawnService } from "../../../services/spawnService";
+import { AssetService } from "../../../services/assetService";
+import { getDefaultTrigger, createSpawnAsset } from "../../../types/spawn";
+import type { Spawn } from "../../../types/spawn";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import type { MediaAsset } from "../../../types/media";
+
+vi.mock("../../../hooks/useLayout");
+vi.mock("../../../services/spawnService");
+vi.mock("../../../services/assetService");
+
+const mockUsePanelState = vi.mocked(usePanelState);
+const mockSpawnService = vi.mocked(SpawnService);
+const mockAssetService = vi.mocked(AssetService);
+
+const makeSpawn = (): Spawn => {
+  const sa1 = createSpawnAsset("asset-1", 0, undefined, "sa1");
+  const sa2 = createSpawnAsset("asset-2", 1, undefined, "sa2");
+  return {
+    id: "spawn-1",
+    name: "Test Spawn",
+    description: "",
+    enabled: true,
+    trigger: getDefaultTrigger("manual"),
+    duration: 0,
+    assets: [sa1, sa2],
+    lastModified: Date.now(),
+    order: 0,
+  };
+};
+
+describe("SpawnEditorWorkspace - Randomization Buckets UI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUsePanelState.mockReturnValue({
+      activeProfileId: "profile-1",
+      selectedSpawnId: "spawn-1",
+      selectedSpawnAssetId: undefined,
+      centerPanelMode: "spawn-settings",
+      setUnsavedChanges: vi.fn(),
+      hasUnsavedChanges: false,
+      profileSpawnSelections: {},
+      setActiveProfile: vi.fn(),
+      selectSpawn: vi.fn(),
+      setCenterPanelMode: vi.fn(),
+      selectSpawnAsset: vi.fn(),
+      clearContext: vi.fn(),
+    } as ReturnType<typeof usePanelState>);
+
+    mockSpawnService.getAllSpawns.mockResolvedValue([makeSpawn()]);
+    mockAssetService.getAssetById = vi.fn(
+      (id: string): MediaAsset | undefined => {
+        if (id === "asset-1")
+          return {
+            id,
+            type: "audio",
+            name: "woo",
+            path: "woo.mp3",
+            isUrl: false,
+          };
+        if (id === "asset-2")
+          return {
+            id,
+            type: "image",
+            name: "woo",
+            path: "woo.png",
+            isUrl: false,
+          };
+        return undefined;
+      }
+    );
+  });
+
+  const renderWithProviders = (ui: React.ReactNode) =>
+    render(
+      <Tooltip.Provider delayDuration={0} skipDelayDuration={0}>
+        {ui}
+      </Tooltip.Provider>
+    );
+
+  it("disables Save when bucket N exceeds enabled member count", async () => {
+    await act(async () => {
+      renderWithProviders(<SpawnEditorWorkspace />);
+    });
+
+    // Create a bucket with Pick N and N=3
+    fireEvent.click(screen.getByRole("button", { name: "Add Bucket" }));
+    const modal = await screen.findByRole("dialog", { name: "Create Bucket" });
+    fireEvent.change(within(modal).getByLabelText("Name"), {
+      target: { value: "Audio bucket" },
+    });
+    fireEvent.change(within(modal).getByLabelText("Selection"), {
+      target: { value: "n" },
+    });
+    fireEvent.change(within(modal).getByLabelText("N"), {
+      target: { value: "3" },
+    });
+    fireEvent.click(within(modal).getByRole("button", { name: "Create" }));
+
+    // Open Edit Members and select the two assets
+    const editButtons = await screen.findAllByRole("button", {
+      name: /Edit Members/i,
+    });
+    fireEvent.click(editButtons[0]);
+    const membersModal = await screen.findByRole("dialog", {
+      name: "Edit Bucket Members",
+    });
+    const checkboxes = within(membersModal).getAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(within(membersModal).getByRole("button", { name: "Done" }));
+
+    // Save should be disabled due to invalid N
+    const saveBtn = screen.getByRole("button", { name: "Save spawn" });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it("shows move confirmation when toggling a member already in another bucket", async () => {
+    await act(async () => {
+      renderWithProviders(<SpawnEditorWorkspace />);
+    });
+
+    // Create first bucket and add first asset
+    fireEvent.click(screen.getByRole("button", { name: "Add Bucket" }));
+    const modalA = await screen.findByRole("dialog", { name: "Create Bucket" });
+    fireEvent.change(within(modalA).getByLabelText("Name"), {
+      target: { value: "Bucket A" },
+    });
+    fireEvent.click(within(modalA).getByRole("button", { name: "Create" }));
+
+    const bucketACardTitle = await screen.findByText("Bucket A");
+    expect(bucketACardTitle).toBeInTheDocument();
+    const firstEditBtn = screen.getAllByRole("button", {
+      name: /Edit Members/i,
+    })[0];
+    fireEvent.click(firstEditBtn);
+    const membersModalA = await screen.findByRole("dialog", {
+      name: "Edit Bucket Members",
+    });
+    const cbsA = within(membersModalA).getAllByRole("checkbox");
+    fireEvent.click(cbsA[0]);
+    fireEvent.click(
+      within(membersModalA).getByRole("button", { name: "Done" })
+    );
+
+    // Create second bucket and toggle same asset -> expect move confirmation
+    fireEvent.click(screen.getByRole("button", { name: "Add Bucket" }));
+    const modalB = await screen.findByRole("dialog", { name: "Create Bucket" });
+    fireEvent.change(within(modalB).getByLabelText("Name"), {
+      target: { value: "Bucket B" },
+    });
+    fireEvent.click(within(modalB).getByRole("button", { name: "Create" }));
+
+    const bucketBCardTitle = await screen.findByText("Bucket B");
+    expect(bucketBCardTitle).toBeInTheDocument();
+    const editBtns = screen.getAllByRole("button", { name: /Edit Members/i });
+    const secondEditBtn = editBtns[editBtns.length - 1];
+    fireEvent.click(secondEditBtn);
+    const membersModalB = await screen.findByRole("dialog", {
+      name: "Edit Bucket Members",
+    });
+    const cbsB = within(membersModalB).getAllByRole("checkbox");
+    fireEvent.click(cbsB[0]);
+
+    expect(
+      await screen.findByText("Move asset to this bucket?")
+    ).toBeInTheDocument();
+  });
+
+  it("shows unsaved-changes guard on mode switch request when dirty", async () => {
+    // Reconfigure layout state to show hasUnsavedChanges
+    mockUsePanelState.mockReturnValue({
+      activeProfileId: "profile-1",
+      selectedSpawnId: "spawn-1",
+      selectedSpawnAssetId: undefined,
+      centerPanelMode: "spawn-settings",
+      setUnsavedChanges: vi.fn(),
+      hasUnsavedChanges: true,
+      profileSpawnSelections: {},
+      setActiveProfile: vi.fn(),
+      selectSpawn: vi.fn(),
+      setCenterPanelMode: vi.fn(),
+      selectSpawnAsset: vi.fn(),
+      clearContext: vi.fn(),
+    } as ReturnType<typeof usePanelState>);
+    mockSpawnService.getAllSpawns.mockResolvedValue([makeSpawn()]);
+
+    await act(async () => {
+      render(<SpawnEditorWorkspace />);
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(
+          "mediaspawner:request-center-switch" as unknown as keyof WindowEventMap,
+          {
+            detail: { mode: "asset-settings", spawnAssetId: "sa1" },
+          } as CustomEventInit
+        )
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Unsaved Changes")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/types/spawn.ts
+++ b/src/types/spawn.ts
@@ -210,6 +210,35 @@ export interface SpawnAssetOverrides {
 }
 
 /**
+ * Bucket-based randomization configuration for selective asset spawning.
+ * Keeping this separate from assets preserves existing override semantics while
+ * allowing flexible selection rules without nesting the asset list.
+ */
+export interface RandomizationBucketMember {
+  /** Reference to a spawn asset included in the bucket */
+  spawnAssetId: string;
+  /** Optional weight used when weighted selection is enabled */
+  weight?: number;
+}
+
+export interface RandomizationBucket {
+  /** Unique identifier for the bucket */
+  id: string;
+  /** Human-readable name for the bucket */
+  name: string;
+  /** Selection strategy for this bucket */
+  selection: "one" | "n";
+  /** Number of members to select when selection is "n" */
+  n?: number;
+  /** Whether to use weights when selecting */
+  weighted?: boolean;
+  /** Hint to avoid selecting the same member(s) consecutively */
+  noImmediateRepeat?: boolean;
+  /** Members of this bucket, each referencing a spawn asset */
+  members: RandomizationBucketMember[];
+}
+
+/**
  * Core spawn interface representing a collection of assets with shared behavior
  *
  * Spawns are the primary unit of work in the spawn-centric architecture.
@@ -237,6 +266,9 @@ export interface Spawn {
 
   /** Array of spawn-specific asset instances */
   assets: SpawnAsset[];
+
+  /** Optional randomization buckets for selective member selection */
+  randomizationBuckets?: RandomizationBucket[];
 
   /** Optional spawn-wide default settings for assets */
   defaultProperties?: Partial<MediaAssetProperties>;

--- a/src/utils/__tests__/randomizationBuckets.test.ts
+++ b/src/utils/__tests__/randomizationBuckets.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { createSpawn, createSpawnAsset } from "../../types/spawn";
+import type { Spawn } from "../../types/spawn";
+import {
+  validateRandomizationBuckets,
+  reconcileBucketsWithAssets,
+} from "../randomizationBuckets";
+
+describe("randomization buckets validation", () => {
+  it("accepts a valid single-pick bucket with existing member", () => {
+    const sa1 = createSpawnAsset("asset-1", 0);
+    const spawn = createSpawn("Test", undefined, [sa1]);
+    const candidate: Spawn = {
+      ...spawn,
+      randomizationBuckets: [
+        {
+          id: "b1",
+          name: "Audio",
+          selection: "one",
+          members: [{ spawnAssetId: sa1.id }],
+        },
+      ],
+    };
+    const result = validateRandomizationBuckets(candidate);
+    expect(result.isValid).toBe(true);
+  });
+
+  it("rejects duplicate membership across buckets", () => {
+    const sa1 = createSpawnAsset("asset-1", 0);
+    const spawn = createSpawn("Test", undefined, [sa1]);
+    const candidate: Spawn = {
+      ...spawn,
+      randomizationBuckets: [
+        {
+          id: "b1",
+          name: "A",
+          selection: "one",
+          members: [{ spawnAssetId: sa1.id }],
+        },
+        {
+          id: "b2",
+          name: "B",
+          selection: "one",
+          members: [{ spawnAssetId: sa1.id }],
+        },
+      ],
+    };
+    const result = validateRandomizationBuckets(candidate);
+    expect(result.isValid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("appears in multiple buckets"))
+    ).toBe(true);
+  });
+
+  it("rejects n greater than enabled members", () => {
+    const sa1 = createSpawnAsset("asset-1", 0);
+    const sa2 = createSpawnAsset("asset-2", 1);
+    sa2.enabled = false;
+    const spawn = createSpawn("Test", undefined, [sa1, sa2]);
+    const candidate: Spawn = {
+      ...spawn,
+      randomizationBuckets: [
+        {
+          id: "b1",
+          name: "Pick2",
+          selection: "n",
+          n: 2,
+          members: [{ spawnAssetId: sa1.id }, { spawnAssetId: sa2.id }],
+        },
+      ],
+    };
+    const result = validateRandomizationBuckets(candidate);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.includes("selects 2"))).toBe(true);
+  });
+
+  it("reconciles buckets by removing members whose spawn assets were deleted", () => {
+    const sa1 = createSpawnAsset("asset-1", 0);
+    const sa2 = createSpawnAsset("asset-2", 1);
+    const spawn = createSpawn("Test", undefined, [sa1, sa2]);
+    const withBucket: Spawn = {
+      ...spawn,
+      randomizationBuckets: [
+        {
+          id: "b1",
+          name: "A",
+          selection: "one",
+          members: [{ spawnAssetId: sa1.id }, { spawnAssetId: sa2.id }],
+        },
+      ],
+    };
+    const afterDelete = reconcileBucketsWithAssets({
+      ...withBucket,
+      assets: [sa1],
+    });
+    expect(afterDelete.randomizationBuckets?.[0].members).toHaveLength(1);
+    expect(afterDelete.randomizationBuckets?.[0].members[0].spawnAssetId).toBe(
+      sa1.id
+    );
+  });
+});

--- a/src/utils/randomizationBuckets.ts
+++ b/src/utils/randomizationBuckets.ts
@@ -1,0 +1,96 @@
+import type { Spawn } from "../types/spawn";
+
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+export function validateRandomizationBuckets(spawn: Spawn): ValidationResult {
+  const errors: string[] = [];
+  const buckets = spawn.randomizationBuckets || [];
+
+  const spawnAssetIds = new Set(spawn.assets.map((a) => a.id));
+  const memberToBucket: Record<string, string> = {};
+
+  for (const bucket of buckets) {
+    if (!bucket.id || bucket.id.trim() === "") {
+      errors.push("Bucket must have a valid id");
+    }
+    if (!bucket.name || bucket.name.trim() === "") {
+      errors.push(`Bucket ${bucket.id || "<no-id>"} must have a name`);
+    }
+    if (bucket.selection === "n") {
+      if (bucket.n === undefined || bucket.n === null) {
+        errors.push(`Bucket ${bucket.name} requires 'n' for selection='n'`);
+      } else if (bucket.n < 1) {
+        errors.push(`Bucket ${bucket.name} has invalid n < 1`);
+      }
+    }
+
+    const uniqueMembers = new Set<string>();
+    for (const m of bucket.members) {
+      if (!spawnAssetIds.has(m.spawnAssetId)) {
+        errors.push(
+          `Bucket ${bucket.name} references missing spawn asset ${m.spawnAssetId}`
+        );
+      }
+      if (uniqueMembers.has(m.spawnAssetId)) {
+        errors.push(
+          `Bucket ${bucket.name} has duplicate member ${m.spawnAssetId}`
+        );
+      } else {
+        uniqueMembers.add(m.spawnAssetId);
+      }
+      if (
+        memberToBucket[m.spawnAssetId] &&
+        memberToBucket[m.spawnAssetId] !== bucket.id
+      ) {
+        errors.push(
+          `Spawn asset ${m.spawnAssetId} appears in multiple buckets (${
+            memberToBucket[m.spawnAssetId]
+          } and ${bucket.id})`
+        );
+      } else {
+        memberToBucket[m.spawnAssetId] = bucket.id;
+      }
+      if (bucket.weighted && m.weight !== undefined && m.weight <= 0) {
+        errors.push(
+          `Bucket ${bucket.name} member ${m.spawnAssetId} has non-positive weight`
+        );
+      }
+    }
+
+    const enabledMemberCount = bucket.members.filter((m) => {
+      const sa = spawn.assets.find((a) => a.id === m.spawnAssetId);
+      return !!sa?.enabled;
+    }).length;
+
+    if (bucket.selection === "n" && bucket.n && bucket.n > enabledMemberCount) {
+      errors.push(
+        `Bucket ${bucket.name} selects ${bucket.n} but only ${enabledMemberCount} enabled members`
+      );
+    }
+
+    if (bucket.members.length === 0) {
+      errors.push(`Bucket ${bucket.name} must have at least one member`);
+    }
+  }
+
+  return { isValid: errors.length === 0, errors };
+}
+
+export function reconcileBucketsWithAssets(spawn: Spawn): Spawn {
+  const buckets = spawn.randomizationBuckets;
+  if (!buckets || buckets.length === 0) return spawn;
+
+  const existingIds = new Set(spawn.assets.map((a) => a.id));
+
+  const pruned = buckets
+    .map((b) => ({
+      ...b,
+      members: b.members.filter((m) => existingIds.has(m.spawnAssetId)),
+    }))
+    .filter((b) => b.members.length > 0);
+
+  return { ...spawn, randomizationBuckets: pruned };
+}


### PR DESCRIPTION
- Define bucket types; add to Spawn and schema
- Validate/reconcile buckets; enforce in SpawnService.updateSpawn
- Integrate buckets section in SpawnEditorWorkspace; gate Save on validity
- Make spawn asset cards denser: icon-only Configure/Remove, Shuffle icon for bucket with tooltip, smaller gaps and chips
- Preserve aria-labels so existing tests remain stable