### PR TITLE
Centralize MediaSpawner event handling with type-safe hook

### DIFF
--- a/src/components/asset-library/AssetLibraryPage.tsx
+++ b/src/components/asset-library/AssetLibraryPage.tsx
@@ -12,6 +12,10 @@ import { Input } from "../ui/Input";
 import { Card } from "../ui/Card";
 import { SyncStatusIndicator, SyncActionsDropdown } from "../common";
 import { StreamerbotService } from "../../services/streamerbotService";
+import {
+  useMediaSpawnerEvent,
+  MediaSpawnerEvents,
+} from "../../hooks/useMediaSpawnerEvent";
 import type { SyncStatusInfo } from "../../types/sync";
 import * as Tooltip from "@radix-ui/react-tooltip";
 
@@ -37,18 +41,12 @@ const AssetLibraryPage: React.FC = () => {
   // Load assets on component mount
   useEffect(() => {
     setAssets(AssetService.getAssets());
-    const handler = () => setAssets(AssetService.getAssets());
-    window.addEventListener(
-      "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-      handler as EventListener,
-    );
-    return () => {
-      window.removeEventListener(
-        "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-        handler as EventListener,
-      );
-    };
   }, []);
+
+  // Listen for asset updates
+  useMediaSpawnerEvent(MediaSpawnerEvents.ASSETS_UPDATED, () => {
+    setAssets(AssetService.getAssets());
+  });
 
   // Subscribe to sync status changes
   useEffect(() => {

--- a/src/components/asset-management/__tests__/AssetManagementPanel.test.tsx
+++ b/src/components/asset-management/__tests__/AssetManagementPanel.test.tsx
@@ -38,6 +38,7 @@ vi.mock("../../../hooks/useLayout", () => ({
 import { SpawnService } from "../../../services/spawnService";
 import { AssetService } from "../../../services/assetService";
 import { usePanelState } from "../../../hooks/useLayout";
+import { MediaSpawnerEvents } from "../../../types/events";
 
 function render(ui: React.ReactNode) {
   return rtlRender(
@@ -441,9 +442,7 @@ describe("AssetManagementPanel (Core Functionality)", () => {
 
       await act(async () => {
         window.dispatchEvent(
-          new Event(
-            "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-          ),
+          new CustomEvent(MediaSpawnerEvents.ASSETS_UPDATED, { detail: {} }),
         );
       });
 

--- a/src/components/common/ImportExportSection.tsx
+++ b/src/components/common/ImportExportSection.tsx
@@ -7,6 +7,10 @@ import { downloadConfiguration } from "../../utils/fileDownload";
 import type { ImportOptions } from "../../services/importExportService";
 import { Button } from "../ui/Button";
 import { cn } from "../../utils/cn";
+import {
+  dispatchMediaSpawnerEvent,
+  MediaSpawnerEvents,
+} from "../../hooks/useMediaSpawnerEvent";
 
 /**
  * Props for the ImportExportSection component
@@ -149,8 +153,9 @@ export function ImportExportSection({
         toast.success(message);
 
         // Dispatch event to refresh the UI
-        window.dispatchEvent(
-          new CustomEvent("mediaspawner:configuration-imported"),
+        dispatchMediaSpawnerEvent(
+          MediaSpawnerEvents.CONFIGURATION_IMPORTED,
+          {},
         );
       } else {
         throw new Error(result.error || "Import failed");

--- a/src/components/common/__tests__/ImportExportSection.test.tsx
+++ b/src/components/common/__tests__/ImportExportSection.test.tsx
@@ -14,6 +14,7 @@ import { ImportExportService } from "../../../services/importExportService";
 import { downloadConfiguration } from "../../../utils/fileDownload";
 import { toast } from "sonner";
 import type { ImportOptions } from "../../../services/importExportService";
+import { MediaSpawnerEvents } from "../../../types/events";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -214,7 +215,7 @@ describe("ImportExportSection", () => {
       expect(toast.success).toHaveBeenCalled();
       expect(dispatchSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: "mediaspawner:configuration-imported",
+          type: MediaSpawnerEvents.CONFIGURATION_IMPORTED,
         }),
       );
     });

--- a/src/components/configuration/__tests__/SpawnEditorWorkspace.Buckets.test.tsx
+++ b/src/components/configuration/__tests__/SpawnEditorWorkspace.Buckets.test.tsx
@@ -11,6 +11,7 @@ import SpawnEditorWorkspace from "../SpawnEditorWorkspace";
 import { usePanelState } from "../../../hooks/useLayout";
 import { SpawnService } from "../../../services/spawnService";
 import { AssetService } from "../../../services/assetService";
+import { MediaSpawnerEvents } from "../../../types/events";
 import { getDefaultTrigger, createSpawnAsset } from "../../../types/spawn";
 import type { Spawn } from "../../../types/spawn";
 import * as Tooltip from "@radix-ui/react-tooltip";
@@ -207,12 +208,9 @@ describe("SpawnEditorWorkspace - Randomization Buckets UI", () => {
 
     act(() => {
       window.dispatchEvent(
-        new CustomEvent(
-          "mediaspawner:request-center-switch" as unknown as keyof WindowEventMap,
-          {
-            detail: { mode: "asset-settings", spawnAssetId: "sa1" },
-          } as CustomEventInit,
-        ),
+        new CustomEvent(MediaSpawnerEvents.REQUEST_CENTER_SWITCH, {
+          detail: { mode: "asset-settings", spawnAssetId: "sa1" },
+        }),
       );
     });
 

--- a/src/components/configuration/asset-settings/__tests__/AssetSettingsForm.test.tsx
+++ b/src/components/configuration/asset-settings/__tests__/AssetSettingsForm.test.tsx
@@ -73,6 +73,7 @@ vi.mock("../../../../utils/assetValidation", () => ({
 import { SpawnService } from "../../../../services/spawnService";
 import { AssetService } from "../../../../services/assetService";
 import { usePanelState } from "../../../../hooks/useLayout";
+import { MediaSpawnerEvents } from "../../../../types/events";
 import {
   resolveEffectiveProperties,
   buildOverridesDiff,
@@ -673,7 +674,7 @@ describe("AssetSettingsForm", () => {
 
       expect(dispatchEventSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: "mediaspawner:spawn-updated",
+          type: MediaSpawnerEvents.SPAWN_UPDATED,
           detail: { spawnId: "spawn1" },
         }),
       );

--- a/src/components/layout/LayoutContext.tsx
+++ b/src/components/layout/LayoutContext.tsx
@@ -2,6 +2,10 @@ import React, { useReducer, useEffect, useRef } from "react";
 import { SpawnProfileService } from "../../services/spawnProfileService";
 import { LayoutContext } from "./LayoutContextTypes";
 import type { LayoutState, LayoutAction } from "./LayoutContextTypes";
+import {
+  dispatchMediaSpawnerEvent,
+  MediaSpawnerEvents,
+} from "../../hooks/useMediaSpawnerEvent";
 
 /**
  * Initial state for the layout context
@@ -189,14 +193,10 @@ export const LayoutProvider: React.FC<LayoutProviderProps> = ({ children }) => {
     // Only dispatch if profile actually changed and we're not in initial load
     if (currentProfileId !== previousProfileId && hasLoadedProfile.current) {
       try {
-        window.dispatchEvent(
-          new CustomEvent(
-            "mediaspawner:profile-changed" as unknown as keyof WindowEventMap,
-            {
-              detail: { profileId: currentProfileId, previousProfileId },
-            } as CustomEventInit,
-          ),
-        );
+        dispatchMediaSpawnerEvent(MediaSpawnerEvents.PROFILE_CHANGED, {
+          profileId: currentProfileId,
+          previousProfileId,
+        });
       } catch {
         // Best-effort notification
       }

--- a/src/components/spawn-list/__tests__/SpawnList.test.tsx
+++ b/src/components/spawn-list/__tests__/SpawnList.test.tsx
@@ -22,6 +22,7 @@ vi.mock("../../../services/spawnService", () => ({
 import { SpawnService } from "../../../services/spawnService";
 import { within } from "@testing-library/react";
 import type { Spawn } from "../../../types/spawn";
+import { MediaSpawnerEvents } from "../../../types/events";
 
 describe("SpawnList", () => {
   it("loads and displays spawns correctly", async () => {
@@ -613,7 +614,9 @@ describe("SpawnList", () => {
       // Dispatch event without detail.id to trigger fallback reload
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent("mediaspawner:spawn-deleted" as unknown as string),
+          new CustomEvent(MediaSpawnerEvents.SPAWN_DELETED, {
+            detail: { id: "" },
+          }),
         );
       });
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,8 @@ export {
   useModalFocusManagement,
   useSkipNavigation,
 } from "./useFocusManagement";
+export {
+  useMediaSpawnerEvent,
+  dispatchMediaSpawnerEvent,
+  MediaSpawnerEvents,
+} from "./useMediaSpawnerEvent";

--- a/src/hooks/useMediaSpawnerEvent.ts
+++ b/src/hooks/useMediaSpawnerEvent.ts
@@ -1,0 +1,63 @@
+import { useEffect, useCallback } from "react";
+import type {
+  MediaSpawnerEventName,
+  MediaSpawnerEventMap,
+} from "../types/events";
+import { MediaSpawnerEvents } from "../types/events";
+
+/**
+ * Type-safe hook for subscribing to MediaSpawner events
+ *
+ * @param eventName - The event name to listen for (type-safe)
+ * @param handler - Handler function that receives the typed event
+ * @param deps - Dependency array for the handler (defaults to empty array)
+ *
+ * @example
+ * ```tsx
+ * useMediaSpawnerEvent(
+ *   MediaSpawnerEvents.SPAWN_UPDATED,
+ *   (event) => {
+ *     if (event.detail.spawnId === selectedSpawnId) void load();
+ *   },
+ *   [selectedSpawnId],
+ * );
+ * ```
+ */
+export function useMediaSpawnerEvent<E extends MediaSpawnerEventName>(
+  eventName: E,
+  handler: (event: MediaSpawnerEventMap[E]) => void,
+  deps: React.DependencyList = [],
+) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableHandler = useCallback(handler, deps);
+
+  useEffect(() => {
+    window.addEventListener(eventName, stableHandler as EventListener);
+    return () => {
+      window.removeEventListener(eventName, stableHandler as EventListener);
+    };
+  }, [eventName, stableHandler]);
+}
+
+/**
+ * Helper to dispatch typed MediaSpawner events
+ *
+ * @param eventName - The event name to dispatch (type-safe)
+ * @param detail - The event detail payload (type-safe based on event name)
+ *
+ * @example
+ * ```tsx
+ * dispatchMediaSpawnerEvent(MediaSpawnerEvents.SPAWN_UPDATED, {
+ *   spawnId: spawn.id,
+ *   updatedSpawn: spawn,
+ * });
+ * ```
+ */
+export function dispatchMediaSpawnerEvent<E extends MediaSpawnerEventName>(
+  eventName: E,
+  detail: MediaSpawnerEventMap[E] extends CustomEvent<infer D> ? D : never,
+): void {
+  window.dispatchEvent(new CustomEvent(eventName, { detail }));
+}
+
+export { MediaSpawnerEvents };

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -5,6 +5,10 @@ import { CacheService, CACHE_KEYS } from "./cacheService";
 import { SpawnService } from "./spawnService";
 import { SpawnProfileService } from "./spawnProfileService";
 import { resolveEffectiveProperties } from "../utils/assetSettingsResolver";
+import {
+  dispatchMediaSpawnerEvent,
+  MediaSpawnerEvents,
+} from "../hooks/useMediaSpawnerEvent";
 
 const STORAGE_KEY = "mediaspawner_assets";
 // No parallel spawn-asset overrides storage; overrides are inline on Spawn.assets
@@ -93,11 +97,7 @@ export class AssetService {
     assets.push(asset);
     this.saveAssets(assets);
     try {
-      window.dispatchEvent(
-        new Event(
-          "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-        ),
-      );
+      dispatchMediaSpawnerEvent(MediaSpawnerEvents.ASSETS_UPDATED, {});
     } catch {
       // Best-effort notification
     }
@@ -135,11 +135,7 @@ export class AssetService {
         if (changed) {
           SpawnProfileService.replaceProfiles(updated);
           try {
-            window.dispatchEvent(
-              new Event(
-                "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-              ),
-            );
+            dispatchMediaSpawnerEvent(MediaSpawnerEvents.ASSETS_UPDATED, {});
           } catch {
             // Best-effort notify
           }
@@ -165,11 +161,7 @@ export class AssetService {
       this.saveAssets(assets);
       try {
         // Notify listeners that assets changed so dependent panels can refresh
-        window.dispatchEvent(
-          new Event(
-            "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-          ),
-        );
+        dispatchMediaSpawnerEvent(MediaSpawnerEvents.ASSETS_UPDATED, {});
       } catch {
         // Best-effort notification
       }
@@ -195,11 +187,7 @@ export class AssetService {
     // Invalidate cache after successful clear
     CacheService.invalidate(CACHE_KEYS.ASSETS);
     try {
-      window.dispatchEvent(
-        new Event(
-          "mediaspawner:assets-updated" as unknown as keyof WindowEventMap,
-        ),
-      );
+      dispatchMediaSpawnerEvent(MediaSpawnerEvents.ASSETS_UPDATED, {});
     } catch {
       // Best-effort notification
     }

--- a/src/services/spawnService.ts
+++ b/src/services/spawnService.ts
@@ -17,6 +17,10 @@ import {
   reconcileBucketsWithAssets,
   validateRandomizationBuckets,
 } from "../utils/randomizationBuckets";
+import {
+  dispatchMediaSpawnerEvent,
+  MediaSpawnerEvents,
+} from "../hooks/useMediaSpawnerEvent";
 
 /**
  * Result of spawn operations
@@ -224,14 +228,10 @@ export class SpawnService {
       }
 
       try {
-        window.dispatchEvent(
-          new CustomEvent(
-            "mediaspawner:spawn-updated" as unknown as keyof WindowEventMap,
-            {
-              detail: { spawnId: reconciled.id, updatedSpawn: reconciled },
-            } as CustomEventInit,
-          ),
-        );
+        dispatchMediaSpawnerEvent(MediaSpawnerEvents.SPAWN_UPDATED, {
+          spawnId: reconciled.id,
+          updatedSpawn: reconciled,
+        });
       } catch {
         // Best-effort notification
       }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,67 @@
+import type { Spawn } from "./spawn";
+
+export const MediaSpawnerEvents = {
+  SPAWN_UPDATED: "mediaspawner:spawn-updated",
+  SPAWN_DELETED: "mediaspawner:spawn-deleted",
+  ASSETS_UPDATED: "mediaspawner:assets-updated",
+  PROFILE_CHANGED: "mediaspawner:profile-changed",
+  REQUEST_CENTER_SWITCH: "mediaspawner:request-center-switch",
+  DRAFT_ASSET_COUNT_CHANGED: "mediaspawner:draft-asset-count-changed",
+  REQUEST_ADD_ASSET_TO_SPAWN: "mediaspawner:request-add-asset-to-spawn",
+  CONFIGURATION_IMPORTED: "mediaspawner:configuration-imported",
+} as const;
+
+export type MediaSpawnerEventName =
+  (typeof MediaSpawnerEvents)[keyof typeof MediaSpawnerEvents];
+
+export interface SpawnUpdatedDetail {
+  spawnId: string;
+  updatedSpawn?: Spawn;
+}
+
+export interface SpawnDeletedDetail {
+  id: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface AssetsUpdatedDetail {
+  // No payload currently used
+}
+
+export interface ProfileChangedDetail {
+  profileId: string | undefined;
+  previousProfileId: string | undefined;
+}
+
+export interface RequestCenterSwitchDetail {
+  mode: "spawn-settings" | "asset-settings";
+  spawnAssetId?: string;
+  skipGuard?: boolean;
+}
+
+export interface DraftAssetCountChangedDetail {
+  spawnId: string;
+  count: number;
+  isDraft: boolean;
+}
+
+export interface RequestAddAssetToSpawnDetail {
+  assetId: string;
+  assetName: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ConfigurationImportedDetail {
+  // No payload currently used
+}
+
+export interface MediaSpawnerEventMap {
+  [MediaSpawnerEvents.SPAWN_UPDATED]: CustomEvent<SpawnUpdatedDetail>;
+  [MediaSpawnerEvents.SPAWN_DELETED]: CustomEvent<SpawnDeletedDetail>;
+  [MediaSpawnerEvents.ASSETS_UPDATED]: CustomEvent<AssetsUpdatedDetail>;
+  [MediaSpawnerEvents.PROFILE_CHANGED]: CustomEvent<ProfileChangedDetail>;
+  [MediaSpawnerEvents.REQUEST_CENTER_SWITCH]: CustomEvent<RequestCenterSwitchDetail>;
+  [MediaSpawnerEvents.DRAFT_ASSET_COUNT_CHANGED]: CustomEvent<DraftAssetCountChangedDetail>;
+  [MediaSpawnerEvents.REQUEST_ADD_ASSET_TO_SPAWN]: CustomEvent<RequestAddAssetToSpawnDetail>;
+  [MediaSpawnerEvents.CONFIGURATION_IMPORTED]: CustomEvent<ConfigurationImportedDetail>;
+}


### PR DESCRIPTION
Replace manual window.addEventListener/removeEventListener patterns with useMediaSpawnerEvent hook. Replace dispatchEvent calls with dispatchMediaSpawnerEvent helper. Define all event names and payload types in src/types/events.ts.

Changes:
- Add MediaSpawnerEvents constants and typed event payloads
- Add useMediaSpawnerEvent hook with automatic cleanup
- Add dispatchMediaSpawnerEvent helper for type-safe dispatch
- Convert 10+ components to use new event utilities
- Remove dead code (unused isActive flags in async effects)
- Update tests to use event constants